### PR TITLE
Stability fixes:

### DIFF
--- a/Source/glTFRuntimeEditor/Private/SkeletalMeshExporterGLTF.cpp
+++ b/Source/glTFRuntimeEditor/Private/SkeletalMeshExporterGLTF.cpp
@@ -3,6 +3,7 @@
 #include "SkeletalMeshExporterGLTF.h"
 #include "Rendering/SkeletalMeshRenderData.h"
 
+#if 0 // We already have an exporter from epic. Registering multiple causes issues.
 USkeletalMeshExporterGLTF::USkeletalMeshExporterGLTF(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
@@ -146,3 +147,4 @@ bool USkeletalMeshExporterGLTF::ExportText(const FExportObjectInnerContext* Cont
 
 	return true;
 }
+#endif

--- a/Source/glTFRuntimeEditor/Public/SkeletalMeshExporterGLTF.h
+++ b/Source/glTFRuntimeEditor/Public/SkeletalMeshExporterGLTF.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "SkeletonExporterGLTF.h"
+#if 0 // We already have an exporter from epic. Registering multiple causes issues.
 #include "SkeletalMeshExporterGLTF.generated.h"
 
 class FglTFExportContextSkeletalMesh : public FglTFExportContextSkeleton
@@ -23,3 +24,4 @@ class GLTFRUNTIMEEDITOR_API USkeletalMeshExporterGLTF : public USkeletonExporter
 public:
 	virtual bool ExportText(const FExportObjectInnerContext* Context, UObject* Object, const TCHAR* Type, FOutputDevice& Ar, FFeedbackContext* Warn, uint32 PortFlags) override;
 };
+#endif


### PR DESCRIPTION
- Disable gltf exporter as it interferes with the one from Epic.
- Move glTFParser out of worker thread as it is handling UObjects.